### PR TITLE
Bump minimum Rust version to 1.30 to use stable macro :vis matcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.21.0
+    - rust: 1.30.0
     - rust: stable
     - os: osx
     - rust: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scoped-tls"
-version = "0.1.2"
+version = "1.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,3 @@ macro for providing scoped access to thread local storage (TLS) so any type can
 be stored into TLS.
 """
 
-[features]
-nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@
 //! ```
 
 #![deny(missing_docs, warnings)]
-#![cfg_attr(feature = "nightly", feature(macro_vis_matcher))]
-#![cfg_attr(feature = "nightly", feature(allow_internal_unstable))]
 
 use std::cell::Cell;
 use std::marker;
@@ -53,26 +51,6 @@ use std::thread::LocalKey;
 
 /// The macro. See the module level documentation for the description and examples.
 #[macro_export]
-#[cfg(not(feature = "nightly"))]
-macro_rules! scoped_thread_local {
-    ($(#[$attrs:meta])* static $name:ident: $ty:ty) => (
-        $(#[$attrs])*
-        static $name: $crate::ScopedKey<$ty> = $crate::ScopedKey {
-            inner: {
-                thread_local!(static FOO: ::std::cell::Cell<usize> = {
-                    ::std::cell::Cell::new(0)
-                });
-                &FOO
-            },
-            _marker: ::std::marker::PhantomData,
-        };
-    )
-}
-
-/// The macro. See the module level documentation for the description and examples.
-#[macro_export]
-#[allow_internal_unstable]
-#[cfg(feature = "nightly")]
 macro_rules! scoped_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty) => (
         $(#[$attrs])*


### PR DESCRIPTION
Closes #9.
Closes #5.

The `macro_vis_matcher` feature has been [stabilized in 1.30](https://github.com/rust-lang/rust/pull/53370) so there's no need to use a separate `nightly` feature flag for that.

This technically bumps the minimum required `rustc` version to 1.30 so I'm not sure how we should proceed - we could either bump it to 0.2 so that people can opt-in into bumping it or rename the existing feature flag to `rust-1.30` or similar and add the `macro_vis_matcher` to the linted against bare `#[allow_internal_unstable]`.

I tested the lint fix using `cargo check --all-features` with a recent nightly compiler, @alexcrichton please let me know if I missed something!