### PR TITLE
Implement mutable and HKT extensions to `scoped_thread_local` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ Library implementation of the standard library's old `scoped_thread_local!`
 macro for providing scoped access to thread local storage (TLS) so any type can
 be stored into TLS.
 """
-


### PR DESCRIPTION
This PR implements two extensions to the `scoped_thread_local` macro.

## Mutable types

This mirrors the API of `ScopedKey` but for mutable references instead. It is used like this:

```rust
scoped_thread_local!(static mut FOO: u32);
```

## Higher-kinded types

This allows using types which are covariant in some lifetime parameter. The type must be `Copy`, but can use the lifetime parameter anywhere as long as it remains covariant. It is used like this:

```rust
scoped_thread_local!(static FOO: for<'a> Foo<'a>);
```

## Relax `Sized` bound

This PR also relaxes the `Sized` bound on the two new variants, but it leaves the original variant as-is. (Although it may make sense to change that one too).