### PR TITLE
change fields of ScopedKey to be private to prevent UB from safe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,7 @@
 
 #![deny(missing_docs, warnings)]
 
-use std::cell::Cell;
-use std::marker;
-use std::thread::LocalKey;
+use std::{cell::Cell, marker, thread::LocalKey};
 
 /// The macro. See the module level documentation for the description and examples.
 #[macro_export]
@@ -117,7 +115,8 @@ impl<T> ScopedKey<T> {
     /// # }
     /// ```
     pub fn set<F, R>(&'static self, t: &T, f: F) -> R
-        where F: FnOnce() -> R
+    where
+        F: FnOnce() -> R,
     {
         struct Reset {
             key: &'static LocalKey<Cell<*const ()>>,
@@ -133,7 +132,10 @@ impl<T> ScopedKey<T> {
             c.set(t as *const T as *const ());
             prev
         });
-        let _reset = Reset { key: self.inner, val: prev };
+        let _reset = Reset {
+            key: self.inner,
+            val: prev,
+        };
         f()
     }
 
@@ -162,14 +164,15 @@ impl<T> ScopedKey<T> {
     /// # }
     /// ```
     pub fn with<F, R>(&'static self, f: F) -> R
-        where F: FnOnce(&T) -> R
+    where
+        F: FnOnce(&T) -> R,
     {
         let val = self.inner.with(|c| c.get());
-        assert!(!val.is_null(), "cannot access a scoped thread local \
-                                 variable without calling `set` first");
-        unsafe {
-            f(&*(val as *const T))
-        }
+        assert!(
+            !val.is_null(),
+            "cannot access a scoped thread local variable without calling `set` first"
+        );
+        unsafe { f(&*(val as *const T)) }
     }
 
     /// Test whether this TLS key has been `set` for the current thread.
@@ -180,9 +183,11 @@ impl<T> ScopedKey<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
-    use std::sync::mpsc::{channel, Sender};
-    use std::thread;
+    use std::{
+        cell::Cell,
+        sync::mpsc::{channel, Sender},
+        thread,
+    };
 
     scoped_thread_local!(static FOO: u32);
 
@@ -239,9 +244,7 @@ mod tests {
             FOO.set(&1, || {
                 let _r = Check(tx);
 
-                FOO.set(&2, || {
-                    panic!()
-                });
+                FOO.set(&2, || panic!());
             });
         });
 


### PR DESCRIPTION
Also adds a `#[doc(hidden)]` `const unsafe fn new()` method, which is what the macro now uses.
Fixes: #23